### PR TITLE
allow multiple apps pointing to one chart

### DIFF
--- a/.github/workflows/go-unit-tests.yaml
+++ b/.github/workflows/go-unit-tests.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.21.x, 1.22.x ]
+        go-version: [ 1.22.x ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     env:

--- a/src/argoaction/git.go
+++ b/src/argoaction/git.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -157,7 +158,9 @@ var addLabelsToPullRequest = func(githubClient internal.GitHubClient, pr *github
 }
 
 var handleNewVersion = func(chart string, newest *semver.Version, path string, gitOps internal.GitOperations, cfg *models.Config, action internal.ActionInterface, osw internal.OSInterface, githubClient internal.GitHubClient) error {
-	branchName := "update-" + chart
+	filename := filepath.Base(path)
+	filename = strings.TrimSuffix(filename, filepath.Ext(filename))
+	branchName := "update-" + chart + "-" + filename + "-" + newest.String()
 	err := createNewBranch(gitOps, cfg.TargetBranch, branchName)
 	if err != nil {
 		action.Fatalf("Error creating new branch: %v\n", err)


### PR DESCRIPTION
1. use more complex branch name to avoid conflicts
2. disable go 1.21 in test pipeline