### PR TITLE
refactor: do not error out if update branch is already present

### DIFF
--- a/src/argoaction/parse.go
+++ b/src/argoaction/parse.go
@@ -63,29 +63,29 @@ func getNewestVersionFromNative(url string, chart string, targetRevision string,
 
 	body, err := utils.GetHTTPResponse(url)
 	if err != nil {
-		action.Debugf("failed to get HTTP response: %v\n", err)
+		action.Debugf("failed to get HTTP response: %v", err)
 		return nil, err
 	}
 
 	err = yaml.Unmarshal(body, &index)
 	if err != nil {
-		action.Debugf("failed to unmarshal YAML body: %v\n", err)
+		action.Debugf("failed to unmarshal YAML body: %v", err)
 		return nil, err
 	}
 
 	if index.Entries == nil {
-		action.Debugf("No entries found in index at %s\n", url)
+		action.Debugf("No entries found in index at %s", url)
 		return nil, nil
 	}
 
 	if _, ok := index.Entries[chart]; !ok || len(index.Entries[chart]) == 0 {
-		action.Debugf("Chart entry %s does not exist or is empty at %s\n", chart, url)
+		action.Debugf("Chart entry %s does not exist or is empty at %s", chart, url)
 		return nil, nil
 	}
 
 	newest, err := parseNativeNewest(targetRevision, index.Entries[chart], skipPreRelease)
 	if err != nil {
-		action.Debugf("Error comparing versions: %v\n", err)
+		action.Debugf("Error comparing versions: %v", err)
 		return nil, err
 	}
 
@@ -95,7 +95,7 @@ func getNewestVersionFromNative(url string, chart string, targetRevision string,
 var parseOCINewest = func(tags *models.TagsList, targetVersion string, action internal.ActionInterface, skipPreRelease bool) (*semver.Version, error) {
 	target, err := semver.NewVersion(targetVersion)
 	if err != nil {
-		action.Debugf("Error parsing target version: %v\n", err)
+		action.Debugf("Error parsing target version: %v", err)
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ var parseOCINewest = func(tags *models.TagsList, targetVersion string, action in
 	for _, tag := range tags.Tags {
 		upstream, err := semver.NewVersion(tag)
 		if err != nil {
-			action.Debugf("Error parsing tag version: %v\n", err)
+			action.Debugf("Error parsing tag version: %v", err)
 			return nil, err
 		}
 
@@ -146,12 +146,12 @@ func getNewestVersionFromOCI(url string, chart string, targetRevision string, ac
 
 	newest, err := parseOCINewest(tags, targetRevision, action, skipPreRelease)
 	if err != nil {
-		action.Debugf("Error comparing versions: %v\n", err)
+		action.Debugf("Error comparing versions: %v", err)
 		return nil, err
 	}
 
 	if err != nil {
-		action.Debugf("Error getting tags: %v\n", err)
+		action.Debugf("Error getting tags: %v", err)
 		return nil, err
 	}
 

--- a/src/argoaction/parse_test.go
+++ b/src/argoaction/parse_test.go
@@ -31,10 +31,16 @@ func TestReadAndParseYAML(t *testing.T) {
 		skipPreRelease bool
 	}{
 		{
-			name:         "Test Case 1",
-			path:         "test.yaml",
-			readFileData: []byte("spec:\n  source:\n    chart: chart1\n    repoURL: repoURL1\n    targetRevision: targetRevision1\n"),
-			readFileErr:  nil,
+			name: "Test Case 1",
+			path: "test.yaml",
+			readFileData: []byte(`
+spec:
+  source:
+    chart: chart1
+    repoURL: repoURL1
+    targetRevision: targetRevision1
+`),
+			readFileErr: nil,
 			expected: &models.Application{
 				Spec: models.Spec{
 					Source: models.Source{

--- a/src/argoaction/process_files.go
+++ b/src/argoaction/process_files.go
@@ -45,7 +45,7 @@ func updateTargetRevision(newest *semver.Version, path string, action internal.A
 		return err
 	}
 
-	lines := strings.Split(string(oldData), "")
+	lines := strings.Split(string(oldData), "\n")
 
 	for i, line := range lines {
 		if strings.Contains(line, "targetRevision:") {
@@ -55,7 +55,7 @@ func updateTargetRevision(newest *semver.Version, path string, action internal.A
 		}
 	}
 
-	newData := strings.Join(lines, "")
+	newData := strings.Join(lines, "\n")
 
 	err = osw.WriteFile(path, []byte(newData), 0644)
 	if err != nil {

--- a/src/argoaction/process_files_test.go
+++ b/src/argoaction/process_files_test.go
@@ -51,8 +51,13 @@ func TestProcessFile(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://test.local/index.yaml", responder)
 
 	t.Run("Skip invalid application manifest", func(t *testing.T) {
-		mockAction.On("Debugf", "Skipping invalid application manifest %s\n", mock.AnythingOfType("[]interface {}")).Once()
-		fileContent := []byte("spec:\n  source:\n    fakechart: chart1\n    repoURL: https://test.local\n")
+		mockAction.On("Debugf", "Skipping invalid application manifest %s", mock.AnythingOfType("[]interface {}")).Once()
+		fileContent := []byte(`
+spec:
+  source:
+    fakechart: chart1
+    repoURL: https://test.local
+`)
 
 		mockOSInterface.On("ReadFile", mock.Anything).Return([]byte(fileContent), nil).Once()
 
@@ -64,8 +69,14 @@ func TestProcessFile(t *testing.T) {
 	})
 
 	t.Run("Skip empty chart, url, and targetRevision", func(t *testing.T) {
-		mockAction.On("Debugf", "Skipping invalid application manifest %s\n", mock.AnythingOfType("[]interface {}")).Once()
-		fileContent := []byte("spec:\n  source:\n    chart: chart1\n    repoURL: https://test.local\n    targetRevision: \n")
+		mockAction.On("Debugf", "Skipping invalid application manifest %s", mock.AnythingOfType("[]interface {}")).Once()
+		fileContent := []byte(`
+spec:
+  source:
+    chart: chart1
+    repoURL: https://test.local
+    targetRevision:
+`)
 		mockOSInterface.On("ReadFile", mock.Anything).Return([]byte(fileContent), nil).Once()
 
 		err := processFile("invalid2.yaml", mockRepo, mockGitHubClient, cfg, mockAction, mockOSInterface)
@@ -76,10 +87,16 @@ func TestProcessFile(t *testing.T) {
 	})
 
 	t.Run("Check chart, url, and targetRevision", func(t *testing.T) {
-		mockAction.On("Debugf", "Checking %s from %s, current version is %s\n", mock.AnythingOfType("[]interface {}")).Once()
-		mockAction.On("Infof", "There is a newer %s version: %s\n", mock.AnythingOfType("[]interface {}")).Once()
-		mockAction.On("Infof", "Create PR is disabled, skipping PR creation for %s\n", mock.AnythingOfType("[]interface {}")).Once()
-		fileContent := []byte("spec:\n  source:\n    chart: chart1\n    repoURL: https://test.local\n    targetRevision: 0.1.2 \n")
+		mockAction.On("Debugf", "Checking %s from %s, current version is %s", mock.AnythingOfType("[]interface {}")).Once()
+		mockAction.On("Infof", "There is a newer %s version: %s", mock.AnythingOfType("[]interface {}")).Once()
+		mockAction.On("Infof", "Create PR is disabled, skipping PR creation for %s", mock.AnythingOfType("[]interface {}")).Once()
+		fileContent := []byte(`
+spec:
+  source:
+    chart: chart1
+    repoURL: https://test.local
+    targetRevision: 0.1.2
+`)
 		mockOSInterface.On("ReadFile", mock.Anything).Return([]byte(fileContent), nil).Once()
 
 		err := processFile("valid.yaml", mockRepo, mockGitHubClient, cfg, mockAction, mockOSInterface)


### PR DESCRIPTION
- do not error out if update branch is already present or up to date
- improve error logging and formatting
- remove useless \n from logging
- better yaml formatting